### PR TITLE
Improve RingBuffer available()

### DIFF
--- a/libs/RingBuffer/src/RingBuffer.cpp
+++ b/libs/RingBuffer/src/RingBuffer.cpp
@@ -110,17 +110,9 @@ size_t RingBuffer::size() const
 
 size_t RingBuffer::available() const
 {
-	if (m_head == m_tail)
-	{
-		return m_isFull ? 0 : m_capacity;
-	}
-	else if (m_head > m_tail)
-	{
-		return m_capacity - (m_head - m_tail);
-	}
-
-	// m_tail > m_head
-	return m_tail - m_head - 1;
+        // The number of free bytes is simply the capacity minus the
+        // number of bytes currently stored in the buffer.
+        return m_capacity - size();
 }
 
 bool RingBuffer::empty() const

--- a/libs/RingBuffer/tests/tests.cpp
+++ b/libs/RingBuffer/tests/tests.cpp
@@ -130,3 +130,22 @@ TEST_F (RingBufferTest, BufferWrapAround)
     EXPECT_TRUE(ringBuffer->pop(poppedData, sizeof(poppedData)));
     EXPECT_EQ(memcmp(secondData, poppedData, sizeof(secondData)), 0);
 }
+
+TEST_F (RingBufferTest, Available_TailGreaterThanHead)
+{
+    // Perform a sequence of push/pop operations that will cause the
+    // internal tail index to advance past the head index.
+    uint8_t firstData[900] = { 0 };
+    uint8_t secondData[700] = { 0 };
+    uint8_t temp[800];
+
+    ASSERT_TRUE(ringBuffer->push(firstData, sizeof(firstData)));
+    ASSERT_TRUE(ringBuffer->pop(temp, 800));
+    ASSERT_TRUE(ringBuffer->push(secondData, sizeof(secondData)));
+
+    // After the above operations the buffer contains 800 bytes of data
+    // and the tail index is greater than the head index. Available should
+    // therefore report the remaining capacity correctly.
+    EXPECT_EQ(ringBuffer->size(), 800u);
+    EXPECT_EQ(ringBuffer->available(), 1024u - 800u);
+}


### PR DESCRIPTION
## Summary
- simplify `RingBuffer::available()` to rely on `m_capacity - size()`
- add unit test to verify availability when buffer wraps (m_tail > m_head)

## Testing
- `./build.sh --test`

------
https://chatgpt.com/codex/tasks/task_e_6861e44eb9388329ae09c4cfad6759db