### PR TITLE
Switch RingBuffer indices to size_t

### DIFF
--- a/libs/RingBuffer/include/RingBuffer.hpp
+++ b/libs/RingBuffer/include/RingBuffer.hpp
@@ -17,8 +17,8 @@ public:
 
 private:
 	uint8_t*	m_buffer = nullptr;
-	int			m_head = 0;
-	int			m_tail = 0;
+	size_t          m_head = 0;
+	size_t          m_tail = 0;
 	size_t		m_capacity = 0;
 	bool		m_isFull = false;
 };


### PR DESCRIPTION
## Summary
- use `size_t` for ring buffer head/tail indices
- keep calculations unchanged

## Testing
- `./build.sh --all`

------
https://chatgpt.com/codex/tasks/task_e_6861e8fd70008329bc77d528acd791a8