### PR TITLE
Implement move-only semantics for RingBuffer

### DIFF
--- a/libs/RingBuffer/include/RingBuffer.hpp
+++ b/libs/RingBuffer/include/RingBuffer.hpp
@@ -5,8 +5,16 @@
 
 class RingBuffer {
 public:
-	RingBuffer(size_t size);
-	~RingBuffer();
+        RingBuffer(size_t size);
+        ~RingBuffer();
+
+        // Delete copy operations
+        RingBuffer(const RingBuffer&) = delete;
+        RingBuffer& operator=(const RingBuffer&) = delete;
+
+        // Allow move semantics
+        RingBuffer(RingBuffer&& other) noexcept;
+        RingBuffer& operator=(RingBuffer&& other) noexcept;
 
 	bool push(uint8_t* data, size_t size);
 	bool pop(uint8_t* data, size_t size);

--- a/libs/RingBuffer/src/RingBuffer.cpp
+++ b/libs/RingBuffer/src/RingBuffer.cpp
@@ -10,7 +10,43 @@ RingBuffer::RingBuffer(size_t size)
 
 RingBuffer::~RingBuffer()
 {
-	delete[] m_buffer;
+        delete[] m_buffer;
+}
+
+RingBuffer::RingBuffer(RingBuffer&& other) noexcept
+        : m_buffer(other.m_buffer)
+        , m_head(other.m_head)
+        , m_tail(other.m_tail)
+        , m_capacity(other.m_capacity)
+        , m_isFull(other.m_isFull)
+{
+        other.m_buffer = nullptr;
+        other.m_head = 0;
+        other.m_tail = 0;
+        other.m_capacity = 0;
+        other.m_isFull = false;
+}
+
+RingBuffer& RingBuffer::operator=(RingBuffer&& other) noexcept
+{
+        if (this != &other)
+        {
+                delete[] m_buffer;
+
+                m_buffer = other.m_buffer;
+                m_head = other.m_head;
+                m_tail = other.m_tail;
+                m_capacity = other.m_capacity;
+                m_isFull = other.m_isFull;
+
+                other.m_buffer = nullptr;
+                other.m_head = 0;
+                other.m_tail = 0;
+                other.m_capacity = 0;
+                other.m_isFull = false;
+        }
+
+        return *this;
 }
 
 bool RingBuffer::push(uint8_t* data, size_t size)

--- a/libs/RingBuffer/tests/tests.cpp
+++ b/libs/RingBuffer/tests/tests.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <type_traits>
 #include "RingBuffer.hpp"
 
 class RingBufferTest
@@ -148,4 +149,28 @@ TEST_F (RingBufferTest, Available_TailGreaterThanHead)
     // therefore report the remaining capacity correctly.
     EXPECT_EQ(ringBuffer->size(), 800u);
     EXPECT_EQ(ringBuffer->available(), 1024u - 800u);
+}
+
+TEST(RingBufferTypeTraits, CopyAndMoveProperties)
+{
+    EXPECT_FALSE(std::is_copy_constructible_v<RingBuffer>);
+    EXPECT_FALSE(std::is_copy_assignable_v<RingBuffer>);
+    EXPECT_TRUE(std::is_move_constructible_v<RingBuffer>);
+    EXPECT_TRUE(std::is_move_assignable_v<RingBuffer>);
+}
+
+TEST(RingBufferMoveTest, MoveConstructorAndAssignment)
+{
+    RingBuffer rb1(16);
+    uint8_t data[4] = {1, 2, 3, 4};
+    ASSERT_TRUE(rb1.push(data, sizeof(data)));
+
+    RingBuffer rb2(std::move(rb1));
+    EXPECT_EQ(rb2.size(), sizeof(data));
+    EXPECT_EQ(rb1.size(), 0u);
+
+    RingBuffer rb3(8);
+    rb3 = std::move(rb2);
+    EXPECT_EQ(rb3.size(), sizeof(data));
+    EXPECT_EQ(rb2.size(), 0u);
 }


### PR DESCRIPTION
## Summary
- prevent copying RingBuffer
- add move constructor and move assignment
- test type traits and behaviour for moves

## Testing
- `./build.sh --test`

------
https://chatgpt.com/codex/tasks/task_e_6861ea7054188329885a6bca18e86213