### PR TITLE
Remove duplicate compile definitions

### DIFF
--- a/libs/Calculator/CMakeLists.txt
+++ b/libs/Calculator/CMakeLists.txt
@@ -27,12 +27,7 @@ set_target_properties(${LIBRARY_NAME} PROPERTIES OUTPUT_NAME "${LIBRARY_NAME}" P
 
 # Set compile definitions based on the configuration
 target_compile_definitions(${LIBRARY_NAME} PRIVATE
-	$<$<CONFIG:Debug>:DEBUG_BUILD>
-)
-
-# Set compile definitions based on the configuration
-target_compile_definitions(${LIBRARY_NAME} PRIVATE
-	$<$<CONFIG:Debug>:DEBUG_BUILD>
+        $<$<CONFIG:Debug>:DEBUG_BUILD>
 )
 
 # Set include directories for linking

--- a/libs/RingBuffer/CMakeLists.txt
+++ b/libs/RingBuffer/CMakeLists.txt
@@ -27,12 +27,7 @@ set_target_properties(${LIBRARY_NAME} PROPERTIES OUTPUT_NAME "${LIBRARY_NAME}" P
 
 # Set compile definitions based on the configuration
 target_compile_definitions(${LIBRARY_NAME} PRIVATE
-	$<$<CONFIG:Debug>:DEBUG_BUILD>
-)
-
-# Set compile definitions based on the configuration
-target_compile_definitions(${LIBRARY_NAME} PRIVATE
-	$<$<CONFIG:Debug>:DEBUG_BUILD>
+        $<$<CONFIG:Debug>:DEBUG_BUILD>
 )
 
 # Set include directories for linking


### PR DESCRIPTION
## Summary
- clean up duplicate `target_compile_definitions` blocks in Calculator and RingBuffer

## Testing
- `./build.sh --debug`

------
https://chatgpt.com/codex/tasks/task_e_6861f41478c88329b3f0bfff388b497f