### PR TITLE
Fix ctest invocation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -73,7 +73,7 @@ function build() {
       # Run tests and generate coverage report
       echo "Running Tests..."
       rm -f *.info
-      ctest -C $build_type --coverage --verbose --output-on-failure
+      ctest -C $build_type --verbose --output-on-failure
 
       if command -v lcov >/dev/null 2>&1 && command -v genhtml >/dev/null 2>&1; then
         if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/build.sh
+++ b/build.sh
@@ -84,7 +84,7 @@ function build() {
         lcov --remove coverage.info '/usr/include/*' -o cov_test_filtered.info
         lcov --remove cov_test_filtered.info '/Applications/Xcode.app/*' -o cov_test_filtered.info
         lcov --remove cov_test_filtered.info '*/_deps/*'  -o cov_test_filtered.info
-        lcov --remove cov_test_filtered.info '*/Testing/*' -o cov_test_filtered.info
+        lcov --remove cov_test_filtered.info '*/Testing/*' --ignore-errors unused -o cov_test_filtered.info
         genhtml cov_test_filtered.info --output-directory coverage_report
         echo "Coverage report generated at $(realpath coverage_report/index.html)"
       else

--- a/build.sh
+++ b/build.sh
@@ -76,11 +76,11 @@ function build() {
       ctest -C $build_type --verbose --output-on-failure
 
       if command -v lcov >/dev/null 2>&1 && command -v genhtml >/dev/null 2>&1; then
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-          lcov --directory build --capture --output-file coverage.info
-        else
-          lcov --directory . --capture --output-file coverage.info
-        fi
+          if [[ "$OSTYPE" == "darwin"* ]]; then
+            lcov --directory build --capture --output-file coverage.info --ignore-errors mismatch
+          else
+            lcov --directory . --capture --output-file coverage.info --ignore-errors mismatch
+          fi
         lcov --remove coverage.info '/usr/include/*' -o cov_test_filtered.info
         lcov --remove cov_test_filtered.info '/Applications/Xcode.app/*' -o cov_test_filtered.info
         lcov --remove cov_test_filtered.info '*/_deps/*'  -o cov_test_filtered.info


### PR DESCRIPTION
## Summary
- fix ctest invocation for coverage by removing unsupported flag

## Testing
- `./build.sh --all`

------
https://chatgpt.com/codex/tasks/task_e_68620179cd108329948fd9e5aea96443